### PR TITLE
Remove fixed_ips from quota

### DIFF
--- a/etc/openstack-config/openstack-config.yml
+++ b/etc/openstack-config/openstack-config.yml
@@ -83,7 +83,6 @@ openstack_project_quotas:
   backup_gigabytes: -1
   backups: -1
   cores: 250
-  fixed_ips: 10
   floatingip: 10
   gigabytes: 10000
   injected_file_size: -1
@@ -102,7 +101,6 @@ openstack_unlimited_quotas:
   backup_gigabytes: -1
   backups: -1
   cores: -1
-  fixed_ips: -1
   floatingip: -1
   gigabytes: -1
   injected_file_size: -1


### PR DESCRIPTION
As Fixed ip references are removed from nova-api from 2023.1 onwards, they are removed from quotas.